### PR TITLE
Update 5.md: correct display asdf info for apple silicon

### DIFF
--- a/ruby/5.md
+++ b/ruby/5.md
@@ -58,7 +58,7 @@ You should see configuration commands for asdf on the last line. For Mac Intel:
 On Apple Silicon:
 
 ```bash
-. /opt/homebrew/opt/asdf/asdf.sh
+. /opt/homebrew/opt/asdf/libexec/asdf.sh
 ```
 
 Configuration for asdf should always be the last line in the `~/.zshrc` file, after setting any `$PATH` configuration.


### PR DESCRIPTION
before: 
. /opt/homebrew/opt/asdf/asdf.sh

now: 
. /opt/homebrew/opt/asdf/libexec/asdf.sh